### PR TITLE
Add terms

### DIFF
--- a/lib/ruler_coaster.rb
+++ b/lib/ruler_coaster.rb
@@ -1,4 +1,5 @@
 require 'ruler_coaster/parser'
+require 'ruler_coaster/term/base'
 require 'ruler_coaster/operator/base'
 require 'ruler_coaster/logic/base'
 require 'ruler_coaster/rule'

--- a/lib/ruler_coaster/operator/base.rb
+++ b/lib/ruler_coaster/operator/base.rb
@@ -1,11 +1,18 @@
 module RulerCoaster
   module Operator
     class Base
-      attr_reader :assert_value
+      attr_reader :assert_value,
+                  :value_type
 
       def initialize(value, value_type = nil)
-        @assert_value = \
-          build_term(value, infere_value_type(value_type, value)).value
+        @value_type = infere_value_type(value_type, value)
+        @assert_value = build_term(value, @value_type).value
+      end
+
+      protected
+
+      def term_for(value)
+        Term.call(value, @value_type).value
       end
 
       private

--- a/lib/ruler_coaster/operator/base.rb
+++ b/lib/ruler_coaster/operator/base.rb
@@ -11,7 +11,7 @@ module RulerCoaster
       private
 
       def build_term(value, value_type)
-        value.is_a?(Term::Base) ? value : Term.(value, value_type)
+        value.is_a?(Term::Base) ? value : Term.call(value, value_type)
       end
 
       def infere_value_type(type, value)
@@ -22,11 +22,9 @@ module RulerCoaster
           Array => 'array'
         }
 
-        if type.nil?
-          mapping[value.class] || 'string'
-        else
-          type
-        end
+        return mapping[value.class] || 'string' if type.nil?
+
+        type
       end
     end
   end

--- a/lib/ruler_coaster/operator/base.rb
+++ b/lib/ruler_coaster/operator/base.rb
@@ -3,8 +3,30 @@ module RulerCoaster
     class Base
       attr_reader :assert_value
 
-      def initialize(assert_value)
-        @assert_value = assert_value
+      def initialize(value, value_type = nil)
+        @assert_value = \
+          build_term(value, infere_value_type(value_type, value)).value
+      end
+
+      private
+
+      def build_term(value, value_type)
+        value.is_a?(Term::Base) ? value : Term.(value, value_type)
+      end
+
+      def infere_value_type(type, value)
+        mapping = {
+          String => 'string',
+          Fixnum => 'number',
+          Float => 'decimal',
+          Array => 'array'
+        }
+
+        if type.nil?
+          mapping[value.class] || 'string'
+        else
+          type
+        end
       end
     end
   end

--- a/lib/ruler_coaster/operator/equal.rb
+++ b/lib/ruler_coaster/operator/equal.rb
@@ -2,7 +2,7 @@ module RulerCoaster
   module Operator
     class Equal < Base
       def call(value)
-        assert_value.to_s.casecmp(value.to_s) == 0
+        assert_value.to_s.casecmp(term_for(value).to_s) == 0
       end
     end
   end

--- a/lib/ruler_coaster/operator/greater_than.rb
+++ b/lib/ruler_coaster/operator/greater_than.rb
@@ -2,7 +2,7 @@ module RulerCoaster
   module Operator
     class GreaterThan < Base
       def call(value)
-        value > assert_value
+        term_for(value) > assert_value
       end
     end
   end

--- a/lib/ruler_coaster/parser.rb
+++ b/lib/ruler_coaster/parser.rb
@@ -29,35 +29,35 @@ module RulerCoaster
     end
 
     def visit_equal(node)
-      Operator::Equal.new(node[:value])
+      Operator::Equal.new node[:value], node[:value_type]
     end
 
     def visit_not_equal(node)
-      Operator::NotEqual.new(node[:value])
+      Operator::NotEqual.new node[:value], node[:value_type]
     end
 
     def visit_greater_than(node)
-      Operator::GreaterThan.new(node[:value])
+      Operator::GreaterThan.new node[:value], node[:value_type]
     end
 
     def visit_less_than(node)
-      Operator::LessThan.new(node[:value])
+      Operator::LessThan.new node[:value], node[:value_type]
     end
 
     def visit_contain(node)
-      Operator::Contain.new(node[:value])
+      Operator::Contain.new node[:value], node[:value_type]
     end
 
     def visit_not_contain(node)
-      Operator::NotContain.new(node[:value])
+      Operator::NotContain.new node[:value], node[:value_type]
     end
 
     def visit_empty(node)
-      Operator::Empty.new(node[:value])
+      Operator::Empty.new node[:value], node[:value_type]
     end
 
     def visit_not_empty(node)
-      Operator::NotEmpty.new(node[:value])
+      Operator::NotEmpty.new node[:value], node[:value_type]
     end
 
     module_function

--- a/lib/ruler_coaster/term/array.rb
+++ b/lib/ruler_coaster/term/array.rb
@@ -1,0 +1,31 @@
+module RulerCoaster
+  module Term
+    class Array < Base
+      def value
+        array_value.map(&:to_s).map(&:strip)
+      end
+
+      protected
+
+      def array_value
+        @value.is_a?(::Array) ? @value : @value.split(',')
+      end
+    end
+
+    class ArrayNumber < Term::Array
+      def value
+        array_value.map do |item|
+          item.to_s.strip.to_i
+        end
+      end
+    end
+
+    class ArrayDecimal < Term::Array
+      def value
+        array_value.map do |item|
+          item.to_s.strip.to_f
+        end
+      end
+    end
+  end
+end

--- a/lib/ruler_coaster/term/base.rb
+++ b/lib/ruler_coaster/term/base.rb
@@ -1,0 +1,30 @@
+module RulerCoaster
+  module Term
+    def self.call(value, value_type = nil)
+      mapping = {
+        'string' => Term::String,
+        'number' => Term::Number,
+        'decimal' => Term::Decimal,
+        'array' => Term::Array,
+        'array[string]' => Term::Array,
+        'array[number]' => Term::ArrayNumber,
+        'array[decimal]' => Term::ArrayDecimal,
+      }
+
+      (mapping[value_type] || Term::String).new(value)
+    end
+
+    class Base
+      attr_accessor :value
+
+      def initialize(value)
+        @value = value
+      end
+    end
+  end
+end
+
+require 'ruler_coaster/term/string'
+require 'ruler_coaster/term/number'
+require 'ruler_coaster/term/decimal'
+require 'ruler_coaster/term/array'

--- a/lib/ruler_coaster/term/base.rb
+++ b/lib/ruler_coaster/term/base.rb
@@ -8,7 +8,7 @@ module RulerCoaster
         'array' => Term::Array,
         'array[string]' => Term::Array,
         'array[number]' => Term::ArrayNumber,
-        'array[decimal]' => Term::ArrayDecimal,
+        'array[decimal]' => Term::ArrayDecimal
       }
 
       (mapping[value_type] || Term::String).new(value)

--- a/lib/ruler_coaster/term/decimal.rb
+++ b/lib/ruler_coaster/term/decimal.rb
@@ -1,0 +1,9 @@
+module RulerCoaster
+  module Term
+    class Decimal < Base
+      def value
+        @value.to_f
+      end
+    end
+  end
+end

--- a/lib/ruler_coaster/term/number.rb
+++ b/lib/ruler_coaster/term/number.rb
@@ -1,0 +1,9 @@
+module RulerCoaster
+  module Term
+    class Number < Base
+      def value
+        @value.to_i
+      end
+    end
+  end
+end

--- a/lib/ruler_coaster/term/string.rb
+++ b/lib/ruler_coaster/term/string.rb
@@ -1,0 +1,9 @@
+module RulerCoaster
+  module Term
+    class String < Base
+      def value
+        @value.to_s
+      end
+    end
+  end
+end

--- a/lib/ruler_coaster/version.rb
+++ b/lib/ruler_coaster/version.rb
@@ -1,3 +1,3 @@
 module RulerCoaster
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/ruler_coaster.gemspec
+++ b/ruler_coaster.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ['dev@streetbees.com']
   gem.description   = 'RulerCoaster'
   gem.summary       = 'Rule engine'
-  gem.homepage      = 'https://github.com/streetbees/rule-coaster'
+  gem.homepage      = 'https://github.com/streetbees/ruler-coaster'
 
   gem.files = Dir['README.md', 'lib/**/*']
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/spec/ruler_coaster/operator_spec.rb
+++ b/spec/ruler_coaster/operator_spec.rb
@@ -98,7 +98,8 @@ describe RulerCoaster do
 
       before(:each) do
         @operator = \
-          RulerCoaster.parse(build_operator('greater_than', assert_integer_value))
+          RulerCoaster.parse \
+            build_operator('greater_than', assert_integer_value)
       end
 
       it 'should be the right instance' do
@@ -145,10 +146,10 @@ describe RulerCoaster do
     end
 
     context 'should parse Contain' do
-
       before(:each) do
         @operator = \
-          RulerCoaster.parse(build_operator('contain', assert_array_value))
+          RulerCoaster.parse \
+            build_operator('contain', assert_array_value, 'array[number]')
       end
 
       it 'should be the right instance' do
@@ -166,14 +167,15 @@ describe RulerCoaster do
       it 'should assert false' do
         expect(operator.call(5)).to eq false
       end
-
     end
 
     context 'should parse Not Contain' do
+      let(:assert_array_value) { ['1', '2', '3'] }
 
       before(:each) do
         @operator = \
-          RulerCoaster.parse(build_operator('not_contain', assert_array_value))
+          RulerCoaster.parse \
+            build_operator('not_contain', assert_array_value, 'array[number]')
       end
 
       it 'should be the right instance' do
@@ -181,7 +183,7 @@ describe RulerCoaster do
       end
 
       it 'should have value' do
-        expect(operator.assert_value).to eq assert_array_value
+        expect(operator.assert_value).to eq [1, 2, 3]
       end
 
       it 'should assert true' do
@@ -191,11 +193,9 @@ describe RulerCoaster do
       it 'should assert false' do
         expect(operator.call(2)).to eq false
       end
-
     end
 
     context 'should parse Empty' do
-
       before(:each) do
         @operator = \
           RulerCoaster.parse(build_operator('empty'))
@@ -206,7 +206,7 @@ describe RulerCoaster do
       end
 
       it 'should have value' do
-        expect(operator.assert_value).to be_nil
+        expect(operator.assert_value).to be_empty
       end
 
       it 'should assert true' do
@@ -216,11 +216,9 @@ describe RulerCoaster do
       it 'should assert false' do
         expect(operator.call('abc')).to eq false
       end
-
     end
 
     context 'should parse Not Empty' do
-
       before(:each) do
         @operator = \
           RulerCoaster.parse(build_operator('not_empty'))
@@ -231,7 +229,7 @@ describe RulerCoaster do
       end
 
       it 'should have value' do
-        expect(operator.assert_value).to be_nil
+        expect(operator.assert_value).to be_empty
       end
 
       it 'should assert true' do
@@ -241,9 +239,6 @@ describe RulerCoaster do
       it 'should assert false' do
         expect(operator.call('')).to eq false
       end
-
     end
-
   end
-
 end

--- a/spec/ruler_coaster/parser_spec.rb
+++ b/spec/ruler_coaster/parser_spec.rb
@@ -172,6 +172,24 @@ describe RulerCoaster do
         end
       end
 
+      context 'array 1' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'array',
+            operator: {
+              type: 'equal',
+              value: ['1', '2', '3', '4']
+            }
+          }
+        }
+
+        it 'should compile value to Array[String]' do
+          expect(@rule.operator.assert_value).to eq(['1', '2', '3', '4'])
+          expect(@rule.operator.assert_value.class).to eq(Array)
+        end
+      end
+
       context 'array[string]' do
         let(:json_rule) {
           {

--- a/spec/ruler_coaster/parser_spec.rb
+++ b/spec/ruler_coaster/parser_spec.rb
@@ -1,82 +1,233 @@
 describe RulerCoaster do
-
   context 'Parser' do
-
-    let(:json_rule) {
-      {
-        type: 'and',
-        left: {
-          type: 'rule',
-          path: 'from',
-          operator: {
-            type: 'equal',
-            value: 'Lisboa'
-          }
-        },
-        right: {
-          type: 'or',
-          left: {
-            type: 'rule',
-            path: 'to',
-            operator: {
-              type: 'equal',
-              value: 'Porto'
-            }
-          },
-          right: {
-            type: 'rule',
-            path: 'to',
-            operator: {
-              type: 'equal',
-              value: 'Braga'
-            }
-          }
-        }
-      }
-    }
-
-    let(:nested_json_rule) {
-      {
-        type: 'rule',
-        path: 'a.b.c',
-        operator: {
-          type: 'equal',
-          value: 'Nested'
-        }
-      }
-    }
-
     before(:each) do
       @rule = RulerCoaster.parse(json_rule)
     end
 
-    it 'should compile json to Rule' do
-      expect(@rule).to be_a(RulerCoaster::Logic::And)
-      expect(@rule.left).to be_a(RulerCoaster::Rule)
-      expect(@rule.right).to be_a(RulerCoaster::Logic::Or)
-      expect(@rule.right.left).to be_a(RulerCoaster::Rule)
-      expect(@rule.right.right).to be_a(RulerCoaster::Rule)
+    context 'json rule' do
+      let(:json_rule) {
+        {
+          type: 'and',
+          left: {
+            type: 'rule',
+            path: 'from',
+            operator: {
+              type: 'equal',
+              value: 'Lisboa'
+            }
+          },
+          right: {
+            type: 'or',
+            left: {
+              type: 'rule',
+              path: 'to',
+              operator: {
+                type: 'equal',
+                value: 'Porto'
+              }
+            },
+            right: {
+              type: 'rule',
+              path: 'to',
+              operator: {
+                type: 'equal',
+                value: 'Braga'
+              }
+            }
+          }
+        }
+      }
+
+      let(:nested_json_rule) {
+        {
+          type: 'rule',
+          path: 'a.b.c',
+          operator: {
+            type: 'equal',
+            value: 'Nested'
+          }
+        }
+      }
+
+      it 'should compile json to Rule' do
+        expect(@rule).to be_a(RulerCoaster::Logic::And)
+        expect(@rule.left).to be_a(RulerCoaster::Rule)
+        expect(@rule.right).to be_a(RulerCoaster::Logic::Or)
+        expect(@rule.right.left).to be_a(RulerCoaster::Rule)
+        expect(@rule.right.right).to be_a(RulerCoaster::Rule)
+      end
+
+      it 'should run Rule against an object' do
+        expect(@rule.call({ from: 'Lisboa', to: 'Porto' }).success?).to eq(true)
+        expect(@rule.call({ from: 'Lisboa', to: 'Braga' }).success?).to eq(true)
+        expect(@rule.call({ from: 'Lisboa', to: 'Leiria' }).success?).to eq(false)
+      end
+
+      it 'should run Rule against a top level object' do
+        result = RulerCoaster.parse(nested_json_rule).call({ a: { b: { c: 'Nested'} } })
+
+        expect(result.success?).to eq(true)
+
+        result = RulerCoaster.parse(nested_json_rule).call({ a: { b: { c: 'Nope'} }})
+
+        expect(result.success?).to eq(false)
+
+        expect{ RulerCoaster.parse(nested_json_rule).call({ a: { b: 1 }}) }.to \
+          raise_error(RulerCoaster::NavigationError)
+      end
     end
 
-    it 'should run Rule against an object' do
-      expect(@rule.call({ from: 'Lisboa', to: 'Porto' }).success?).to eq(true)
-      expect(@rule.call({ from: 'Lisboa', to: 'Braga' }).success?).to eq(true)
-      expect(@rule.call({ from: 'Lisboa', to: 'Leiria' }).success?).to eq(false)
+    context 'typed rule' do
+      context 'default as String' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'default',
+            operator: {
+              type: 'equal',
+              value: 'Lisboa'
+            }
+          }
+        }
+
+        it 'should compile value to String' do
+          expect(@rule.operator.assert_value).to eq('Lisboa')
+          expect(@rule.operator.assert_value.class).to eq(String)
+        end
+      end
+
+      context 'string' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'string',
+            operator: {
+              type: 'equal',
+              value: 'Porto',
+              value_type: 'string'
+            }
+          }
+        }
+
+        it 'should compile value to String' do
+          expect(@rule.operator.assert_value).to eq('Porto')
+          expect(@rule.operator.assert_value.class).to eq(String)
+        end
+      end
+
+      context 'number' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'number',
+            operator: {
+              type: 'equal',
+              value: '1234',
+              value_type: 'number'
+            }
+          }
+        }
+
+        it 'should compile value to Fixnum' do
+          expect(@rule.operator.assert_value).to eq(1234)
+          expect(@rule.operator.assert_value.class).to eq(Fixnum)
+        end
+      end
+
+      context 'decimal' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'decimal',
+            operator: {
+              type: 'equal',
+              value: '1234',
+              value_type: 'decimal'
+            }
+          }
+        }
+
+        it 'should compile value to Float' do
+          expect(@rule.operator.assert_value).to eq(1234.0)
+          expect(@rule.operator.assert_value.class).to eq(Float)
+        end
+      end
+
+      context 'array' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'array',
+            operator: {
+              type: 'equal',
+              value: '1,2,3,4',
+              value_type: 'array'
+            }
+          }
+        }
+
+        it 'should compile value to Array[String]' do
+          expect(@rule.operator.assert_value).to eq(['1', '2', '3', '4'])
+          expect(@rule.operator.assert_value.class).to eq(Array)
+        end
+      end
+
+      context 'array[string]' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'array',
+            operator: {
+              type: 'equal',
+              value: '1,2,3,4',
+              value_type: 'array'
+            }
+          }
+        }
+
+        it 'should compile value to Array[String]' do
+          expect(@rule.operator.assert_value).to eq(['1', '2', '3', '4'])
+          expect(@rule.operator.assert_value.class).to eq(Array)
+        end
+      end
+
+      context 'array[number]' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'array',
+            operator: {
+              type: 'equal',
+              value: '1,2,3,4',
+              value_type: 'array[number]'
+            }
+          }
+        }
+
+        it 'should compile value to Array[Integer]' do
+          expect(@rule.operator.assert_value).to eq([1, 2, 3, 4])
+          expect(@rule.operator.assert_value.class).to eq(Array)
+        end
+      end
+
+      context 'array[decimal]' do
+        let(:json_rule) {
+          {
+            type: 'rule',
+            path: 'array',
+            operator: {
+              type: 'equal',
+              value: '1,2,3,4',
+              value_type: 'array[decimal]'
+            }
+          }
+        }
+
+        it 'should compile value to Array[Float]' do
+          expect(@rule.operator.assert_value).to eq([1.0, 2.0, 3.0, 4.0])
+          expect(@rule.operator.assert_value.class).to eq(Array)
+        end
+      end
     end
-
-    it 'should run Rule against a top level object' do
-      result = RulerCoaster.parse(nested_json_rule).call({ a: { b: { c: 'Nested'} } })
-
-      expect(result.success?).to eq(true)
-
-      result = RulerCoaster.parse(nested_json_rule).call({ a: { b: { c: 'Nope'} }})
-
-      expect(result.success?).to eq(false)
-
-      expect{ RulerCoaster.parse(nested_json_rule).call({ a: { b: 1 }}) }.to \
-        raise_error(RulerCoaster::NavigationError)
-    end
-
   end
-
 end

--- a/spec/ruler_coaster/ruler_coaster_spec.rb
+++ b/spec/ruler_coaster/ruler_coaster_spec.rb
@@ -1,7 +1,5 @@
 describe RulerCoaster do
-
   context 'Attributes' do
-
     before(:each) do
       @group = \
         RulerCoaster::Attributes::Base.new \
@@ -26,7 +24,5 @@ describe RulerCoaster do
       expect(result.success?).to eq(false)
       expect(result.blocked).to include(:age)
     end
-
   end
-
 end

--- a/spec/ruler_coaster/ruler_spec.rb
+++ b/spec/ruler_coaster/ruler_spec.rb
@@ -1,7 +1,16 @@
 describe RulerCoaster do
+  context 'Type cast' do
+    it 'should cast interger value for comparison' do
+      result = \
+        RulerCoaster::Rule.new('score', RulerCoaster::Operator::GreaterThan.new('9000', 'number'))
+          .call(score: 9001)
+
+      expect(result).to be_a RulerCoaster::Result
+      expect(result.success?).to eq true
+    end
+  end
 
   context 'No Result' do
-
     it 'should return no result if nil' do
       result = \
         RulerCoaster::Rule.new('gender', RulerCoaster::Operator::Equal.new('m'))
@@ -28,13 +37,10 @@ describe RulerCoaster do
       expect(result).to be_a RulerCoaster::Result
       expect(result.success?).to eq false
     end
-
   end
 
   context 'Examples' do
-
     context 'Only user males above 20 from Porto, PT rule' do
-
       before(:each) do
         @rule = \
           RulerCoaster::Rule.new('user.gender', RulerCoaster::Operator::Equal.new('m'))
@@ -57,11 +63,9 @@ describe RulerCoaster do
 
         expect(result.success?).to eq(true)
       end
-
     end
 
     context 'Only user males above 20 from Porto or London rule' do
-
       before(:each) do
         @rule = \
           RulerCoaster::Rule.new('user.gender', RulerCoaster::Operator::Equal.new('m'))
@@ -108,11 +112,9 @@ describe RulerCoaster do
 
         expect(result.success?).to eq(false)
       end
-
     end
 
     context 'No males from Porto neither London' do
-
       before(:each) do
         @rule = \
           RulerCoaster::Rule.new('user.location.city', RulerCoaster::Operator::Equal.new('Porto'))
@@ -154,11 +156,9 @@ describe RulerCoaster do
 
         expect(result.success?).to eq(false)
       end
-
     end
 
     context "No males that haven't studied in Porto and London" do
-
       before(:each) do
         @rule = \
           RulerCoaster::Rule.new('user.univ_1', RulerCoaster::Operator::Equal.new('Porto'))
@@ -186,9 +186,6 @@ describe RulerCoaster do
 
         expect(result.success?).to eq(true)
       end
-
     end
-
   end
-
 end

--- a/spec/ruler_coaster/ruler_spec.rb
+++ b/spec/ruler_coaster/ruler_spec.rb
@@ -3,7 +3,7 @@ describe RulerCoaster do
     it 'should cast interger value for comparison' do
       result = \
         RulerCoaster::Rule.new('score', RulerCoaster::Operator::GreaterThan.new('9000', 'number'))
-          .call(score: 9001)
+          .call(score: '9001')
 
       expect(result).to be_a RulerCoaster::Result
       expect(result.success?).to eq true

--- a/spec/support/node_helpers.rb
+++ b/spec/support/node_helpers.rb
@@ -16,11 +16,12 @@ module NodeHelpers
     }
   end
 
-  def build_operator(type, value = nil)
-    {
-      type: type,
-      value: value
-    }
+  def build_operator(type, value = nil, value_type = nil)
+    { type: type, value: value }.tap do |hash|
+      unless value_type.nil?
+        hash[:value_type] = value_type
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Terms allows to create rules to match values with a type.
At the moment, all values are compared against a string, if an input is integer, it breaks comparing with `greater_than` operator.

- Allowed value types: `string`, `number`(Fixnum), `decimal`(Float), `array` or `array[string]`, `array[number]`, `array[decimal]`

- When creating a rule, if there's no `operator.value_type`, `ruler-coaster` will try to infer based on the `operator.value`.

- If an `operator.value_type` is sent, the `operator.value` will be casted as the given type.

#### Examples
```ruby
{
  type: 'rule',
  path: 'decimal',
    operator: {
      type: 'equal',
      value: '1234',
      value_type: 'decimal'
  }
}
```
Given the above rule, all values will be casted to `Float` for comparison. That said, `operator.value` will have `1234.0`.